### PR TITLE
Fix asset source paths in sync config

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -22,13 +22,20 @@ repos:
 
       # Assets and resources - uncomment to enable asset syncing:
       - source_path: 'TimeWarp.Architecture/Assets/Overview.md'
-      - source_path: 'Assets/Logo.png'
-      # - source_path: 'Assets/Logo.svg'
-      # - source_path: 'Assets/LogoNoMargin.svg'
-      # - source_path: 'Assets/LogoNoMarginNoShadow.svg'
-      # - source_path: 'Assets/LogoNoWordsOrShadow.svg'
-      # - source_path: 'Assets/LogoNoWordsOrShadow_512x512.png'
-      # - source_path: 'Assets/LogoNoWordsOrShadow_64x64.png'
+      - source_path: 'TimeWarp.Templates/Assets/Logo.png'
+        dest_path: 'Assets/Logo.png'
+      # - source_path: 'TimeWarp.Templates/Assets/Logo.svg'
+      #   dest_path: 'Assets/Logo.svg'
+      # - source_path: 'TimeWarp.Templates/Assets/LogoNoMargin.svg'
+      #   dest_path: 'Assets/LogoNoMargin.svg'
+      # - source_path: 'TimeWarp.Templates/Assets/LogoNoMarginNoShadow.svg'
+      #   dest_path: 'Assets/LogoNoMarginNoShadow.svg'
+      # - source_path: 'TimeWarp.Templates/Assets/LogoNoWordsOrShadow.svg'
+      #   dest_path: 'Assets/LogoNoWordsOrShadow.svg'
+      # - source_path: 'TimeWarp.Templates/Assets/LogoNoWordsOrShadow_512x512.png'
+      #   dest_path: 'Assets/LogoNoWordsOrShadow_512x512.png'
+      # - source_path: 'TimeWarp.Templates/Assets/LogoNoWordsOrShadow_64x64.png'
+      #   dest_path: 'Assets/LogoNoWordsOrShadow_64x64.png'
       
       # Kanban project management files - uncomment to enable project tracking:
       - source_path: 'TimeWarp.Architecture/Kanban/Overview.md'


### PR DESCRIPTION
## Summary
- Fix Logo.png and other asset paths to use correct source location in parent repository

## Changes
Updated `.github/sync-config.yml` to use `TimeWarp.Templates/Assets/` prefix for all asset files, since that's where they actually exist in the parent repository.

## Why this is needed
The sync workflow was unable to find `Assets/Logo.png` because it exists at `TimeWarp.Templates/Assets/Logo.png` in the parent repository.

🤖 Generated with [Claude Code](https://claude.ai/code)