### PR TITLE
Add GetPipelineInfo extension method

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
     <Deterministic>true</Deterministic>
     
     <!-- Unified versioning for all packages -->
-    <Version>13.0.0-beta.3</Version>
+    <Version>13.0.0-beta.4</Version>
   </PropertyGroup>
 
   <!-- Common items -->

--- a/samples/TimeWarp.Mediator.Examples.AspNetCore/Program.cs
+++ b/samples/TimeWarp.Mediator.Examples.AspNetCore/Program.cs
@@ -35,6 +35,10 @@ public static class Program
         services.AddScoped(typeof(IRequestPostProcessor<,>), typeof(GenericRequestPostProcessor<,>));
         services.AddScoped(typeof(IStreamPipelineBehavior<,>), typeof(GenericStreamPipelineBehavior<,>));
 
+        // Demonstrate GetPipelineInfo extension
+        var pipelineInfo = services.GetPipelineInfo();
+        writer.WriteLine(pipelineInfo);
+
         var provider = services.BuildServiceProvider();
 
         return provider.GetRequiredService<IMediator>();

--- a/test/TimeWarp.Mediator.Tests/MicrosoftExtensionsDI/ServiceCollectionExtensionsTests.cs
+++ b/test/TimeWarp.Mediator.Tests/MicrosoftExtensionsDI/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,118 @@
+// Modified by Steven T. Cramer
+using Microsoft.Extensions.DependencyInjection;
+using TimeWarp.Mediator.Pipeline;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace TimeWarp.Mediator.Extensions.Microsoft.DependencyInjection.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void GetPipelineInfo_Should_Return_Empty_Lists_When_No_Components_Registered()
+    {
+        var services = new ServiceCollection();
+        
+        var pipelineInfo = services.GetPipelineInfo();
+        
+        pipelineInfo.ShouldContain("TimeWarp Mediator Pipeline Registrations:");
+        pipelineInfo.ShouldContain("Preprocessors:");
+        pipelineInfo.ShouldContain("(none)");
+        pipelineInfo.ShouldContain("Behaviors:");
+        pipelineInfo.ShouldContain("Postprocessors:");
+    }
+
+    [Fact]
+    public void GetPipelineInfo_Should_List_Registered_Behaviors()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TestBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AnotherTestBehavior<,>));
+        
+        var pipelineInfo = services.GetPipelineInfo();
+        
+        pipelineInfo.ShouldContain("Behaviors:");
+        pipelineInfo.ShouldContain("1. TestBehavior");
+        pipelineInfo.ShouldContain("2. AnotherTestBehavior");
+    }
+
+    [Fact]
+    public void GetPipelineInfo_Should_List_Registered_PreProcessors()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(typeof(IRequestPreProcessor<>), typeof(TestPreProcessor<>));
+        
+        var pipelineInfo = services.GetPipelineInfo();
+        
+        pipelineInfo.ShouldContain("Preprocessors:");
+        pipelineInfo.ShouldContain("1. TestPreProcessor");
+    }
+
+    [Fact]
+    public void GetPipelineInfo_Should_List_Registered_PostProcessors()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(typeof(IRequestPostProcessor<,>), typeof(TestPostProcessor<,>));
+        
+        var pipelineInfo = services.GetPipelineInfo();
+        
+        pipelineInfo.ShouldContain("Postprocessors:");
+        pipelineInfo.ShouldContain("1. TestPostProcessor");
+    }
+
+    [Fact]
+    public void GetPipelineInfo_Should_List_All_Component_Types()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient(typeof(IRequestPreProcessor<>), typeof(TestPreProcessor<>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TestBehavior<,>));
+        services.AddTransient(typeof(IRequestPostProcessor<,>), typeof(TestPostProcessor<,>));
+        
+        var pipelineInfo = services.GetPipelineInfo();
+        
+        pipelineInfo.ShouldContain("Preprocessors:");
+        pipelineInfo.ShouldContain("1. TestPreProcessor");
+        pipelineInfo.ShouldContain("Behaviors:");
+        pipelineInfo.ShouldContain("1. TestBehavior");
+        pipelineInfo.ShouldContain("Postprocessors:");
+        pipelineInfo.ShouldContain("1. TestPostProcessor");
+    }
+
+    private class TestBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            return next();
+        }
+    }
+
+    private class AnotherTestBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            return next();
+        }
+    }
+
+    private class TestPreProcessor<TRequest> : IRequestPreProcessor<TRequest>
+        where TRequest : notnull
+    {
+        public Task Process(TRequest request, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private class TestPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        public Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ServiceCollectionExtensions.GetPipelineInfo()` extension method to inspect registered pipeline components
- Returns a formatted string listing all registered preprocessors, behaviors, and postprocessors
- Allows consumers to inspect and debug their pipeline configuration

## Changes
- Added `GetPipelineInfo()` extension method to `ServiceCollectionExtensions`
- Added comprehensive unit tests for the new functionality
- Updated AspNetCore sample to demonstrate usage
- Bumped version to 13.0.0-beta.4

## Test Plan
- [x] Added unit tests covering all scenarios
- [x] All existing tests pass
- [x] Manually tested with AspNetCore sample - pipeline info displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)